### PR TITLE
[#2] fix protected $_id attributes for subclasses of CRM_Core_Form and CRM_Admin_Form

### DIFF
--- a/CRM/Admin/Form/AdhocChargesItem.php
+++ b/CRM/Admin/Form/AdhocChargesItem.php
@@ -38,7 +38,7 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_AdhocChargesItem extends CRM_Admin_Form {
-  protected $_id = NULL;
+  public $_id = NULL;
 
   function preProcess() {
     parent::preProcess();

--- a/CRM/Admin/Form/Resource.php
+++ b/CRM/Admin/Form/Resource.php
@@ -38,7 +38,7 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_Resource extends CRM_Admin_Form {
-  protected $_id = NULL;
+  public $_id = NULL;
 
   function preProcess() {
     parent::preProcess();

--- a/CRM/Admin/Form/ResourceConfigOption.php
+++ b/CRM/Admin/Form/ResourceConfigOption.php
@@ -38,7 +38,7 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_ResourceConfigOption extends CRM_Admin_Form {
-  protected $_id = NULL;
+  public $_id = NULL;
   protected $_sid = NULL;
 
   function preProcess() {

--- a/CRM/Admin/Form/ResourceConfigSet.php
+++ b/CRM/Admin/Form/ResourceConfigSet.php
@@ -38,7 +38,7 @@ use CRM_Booking_ExtensionUtil as E;
  *
  */
 class CRM_Admin_Form_ResourceConfigSet extends CRM_Admin_Form {
-  protected $_id = NULL;
+  public $_id = NULL;
 
   function preProcess() {
     parent::preProcess();

--- a/CRM/Booking/Form/Booking/Base.php
+++ b/CRM/Booking/Form/Booking/Base.php
@@ -7,7 +7,7 @@ use CRM_Booking_ExtensionUtil as E;
  */
 abstract class CRM_Booking_Form_Booking_Base extends CRM_Core_Form {
 
-  protected $_id;
+  public $_id;
 
   protected $_cid;
 


### PR DESCRIPTION
Using `protected $_id` in subclasses of CRM_Admin_Form runs into an php-error, because the base-classes define this parameter as public.